### PR TITLE
Cast every int8 explicitly to string

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -59,7 +59,14 @@ class Util {
 
   static String fromUtf8(ffi.Pointer<ffi.Int8> str) {
     if (str.address == 0x0) return null;
-    return ffi.Utf8.fromUtf8(str.cast<ffi.Utf8>());
+    String c = "";
+    ffi.Pointer<ffi.Uint8> p = str.cast<ffi.Uint8>();
+    int i = 0;
+    while (p[i] != 0) {
+      c = c + new String.fromCharCode(p[i]);
+      i++;
+    }
+    return c;
   }
 
   static ffi.Pointer<ffi.Int8> toUtf8(String str) {


### PR DESCRIPTION
I have a serial device with the description "Serielles USB-Gerät (COM5)" (note the letter ä which is an extended ASCII character).
When I call
```
final sp = SerialPort(name);
sp.description
```
I get the error message
[ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: FormatException: Missing extension byte (at offset 18)

The proposed PR fixes this issue. It might not be the best implementation though.