### PR TITLE
Fix: Isolate can't be killed on "onPause", and increases infinitely.

### DIFF
--- a/lib/src/reader.dart
+++ b/lib/src/reader.dart
@@ -100,11 +100,7 @@ class _SerialPortReaderImpl implements SerialPortReader {
 
   StreamController<Uint8List> get _controller {
     return __controller ??= StreamController<Uint8List>(
-      onListen: _startRead,
-      onCancel: _cancelRead,
-      onPause: _cancelRead,
-      onResume: _startRead,
-    );
+        onListen: _startRead, onCancel: _cancelRead);
   }
 
   void _startRead() {


### PR DESCRIPTION
As stated in #46, SerialPortReader fails to kill Isolate on the "onPause"` event and creates a new one on the "onResume" event.
So, Isolates increase infinitely.

Below is the example code to reproduce the problem.
You'll see the increased Isolates in the call stack pane, as in the picture.

I'm not sure, but the onPause and onResume events are unnecessary,
because the serial port can buffer input data.

Or, if SerialPortReader needs to handle resume/pause events, 
`_isolate?.kill(priority: Isolate.immediate);` also works well.

```dart
import 'dart:typed_data';

import 'package:libserialport/libserialport.dart';

// ignore_for_file: avoid_print

void main() async {
  print('Available ports:');
  var i = 0;
  for (final name in SerialPort.availablePorts) {
    final sp = SerialPort(name);
    print('${++i}) $name');
    print('\tDescription: ${sp.description}');
    print('\tManufacturer: ${sp.manufacturer}');
    print('\tSerial Number: ${sp.serialNumber}');
    print('\tProduct ID: 0x${sp.productId!.toRadixString(16)}');
    print('\tVendor ID: 0x${sp.vendorId!.toRadixString(16)}');
    sp.dispose();
  }

  final _port = SerialPort("COM3");

  final config = SerialPortConfig();
  config.baudRate = 9600;
  config.bits = 8;
  config.parity = 0;
  _port.config = config;
  _port.openRead();

  final _reader = SerialPortReader(_port);

  final stream = _reader.stream;

  await for (var data in testFunc(stream)) {
    print(data);
  }
}

Stream<String> testFunc(Stream<Uint8List> stream) async* {
  await for (var data in stream) {
    final s = String.fromCharCodes(data);
    yield s; // this emits the onPause event but SerialPortReader can't kill Isolate properly
  }
}

```

![screenshot](https://github.com/jpnurmi/libserialport.dart/assets/56193/3101b4c5-cab8-4c38-a8b3-fe7a46744d95)
