### PR TITLE
Add finalizers

### DIFF
--- a/ffigen.yaml
+++ b/ffigen.yaml
@@ -16,3 +16,10 @@ enums:
 macros:
   include:
     - 'SP_.*'
+functions:
+  symbol-address:
+    include:
+      - sp_close
+      - sp_free_config
+      - sp_free_event_set
+      - sp_free_port

--- a/lib/src/bindings.dart
+++ b/lib/src/bindings.dart
@@ -2084,6 +2084,22 @@ class LibSerialPort {
           'sp_get_lib_version_string');
   late final _sp_get_lib_version_string = _sp_get_lib_version_stringPtr
       .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
+  late final addresses = _SymbolAddresses(this);
+}
+
+class _SymbolAddresses {
+  final LibSerialPort _library;
+  _SymbolAddresses(this._library);
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<sp_port>)>>
+      get sp_free_port => _library._sp_free_portPtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Int32 Function(ffi.Pointer<sp_port>)>>
+      get sp_close => _library._sp_closePtr;
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<sp_port_config>)>>
+      get sp_free_config => _library._sp_free_configPtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<sp_event_set>)>>
+      get sp_free_event_set => _library._sp_free_event_setPtr;
 }
 
 /// Return values.


### PR DESCRIPTION
This PR adds finalizers to native objects. Note that I'm using `sp_close` as a `SerialPort` finalizer which is much more important than `sp_free_port` since it allows to re-open serial port after Flutter's Hot Restart.

While it's perfectly fine to have more than one native finalizer for the same object, Dart SDK does not make guarantees about their execution order. So if you try to add `sp_free_port` finalizer as well, it might be called before `sp_close` finalizer (depending on the environment or Dart SDK version). Ideally underlying `libserialport` will have something like `sp_dispose` with deterministic order (close and free).

Closes #68 
