### PR TITLE
Fix exception on read and throw an exception

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -46,6 +46,11 @@ class Util {
     return ffi.using((arena) {
       final ptr = arena<ffi.Uint8>(bytes);
       final len = call(() => readFunc(ptr));
+
+      if(len < 0) {
+        throw len;
+      }
+      
       return Uint8List.fromList(ptr.asTypedList(len));
     });
   }


### PR DESCRIPTION
This small PR avoid ptr.asTypedList(len) error inside the read function when len is negative (error), it rather throw an exception with "len" which is the error code from readFunc().