### PR TITLE
Add Android support based on usb_serial dart package

### DIFF
--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -1,0 +1,408 @@
+import 'dart:typed_data';
+import 'dart:async';
+
+import 'package:usb_serial/usb_serial.dart';
+
+import 'package:libserialport/src/port.dart';
+import 'package:libserialport/src/enums.dart';
+import 'package:libserialport/src/config.dart';
+import 'package:libserialport/src/error.dart';
+
+/// Serial port Android implementation.
+class SerialPortAndroid implements SerialPort {
+  late UsbDevice _device;
+  UsbPort? port;
+  bool _portOpened = false;
+  Uint8List dataAvailable = Uint8List(0);
+  StreamSubscription? _reading;
+
+  static List<UsbDevice> _currentDevices = [];
+
+  SerialPortAndroid(String listIdx) {
+    List<String> splittedIdx = listIdx.split("+");
+
+    int idx = int.parse(splittedIdx[0]);
+
+    if(splittedIdx.length == 2) {
+      interfaceNumber = int.parse(splittedIdx[1]);
+    }
+
+    if((idx < _currentDevices.length) && (idx >= 0)) {
+      _device = _currentDevices[idx];
+    }
+  }
+
+  SerialPortAndroid.fromAddress(int address) {
+    //Not implemented
+  }
+
+  @override
+  int get address => (_device != null)?_device!.deviceId!:0;
+
+  /// Lists the serial ports available on the system.
+  static Future<List<String>> get availablePorts async {
+    _currentDevices = await UsbSerial.listDevices();
+    List<String> devices = [];
+
+    for(var i=0; i < _currentDevices.length; i++) {
+      int? intCount = _currentDevices[i].interfaceCount;
+
+      //usb_serial doesn't seem to list different serial port from a single usb device, this is a work around.
+      if((intCount != null) && (intCount! > 1)) {
+        for(var j=0; j < intCount!; j++) {
+          //Add the device number to the list.
+          devices.add(i.toString() +"+"+ j.toString());
+        }
+      } else {
+        devices.add(i.toString() +"+-1");
+      }
+    }
+
+    return devices;
+  }
+
+  /// Releases all resources associated with the serial port.
+  ///
+  /// @note Call this function after you're done with the serial port.
+  void dispose() {
+    close();
+  }
+
+  /// Opens the serial port in the specified `mode`.
+  ///
+  /// See also:
+  /// - [SerialPortMode]
+  Future<bool> open({required int mode}) async {
+    UsbPort? p = await _device.create("", interfaceNumber);
+
+    if(p == null) {
+      return false;
+    }
+
+    port = p!;
+
+    _portOpened = await port!.open();
+    return _portOpened;
+  }
+
+  void _startReading() {
+    //Clear data
+    dataAvailable = Uint8List(0);
+
+    //Start listening for data
+    if(port!.inputStream != null) {
+      _reading = port!.inputStream!.listen((Uint8List data) {
+        var b = BytesBuilder();
+        b.add(dataAvailable);
+        b.add(data);
+        dataAvailable = b.toBytes();
+      });
+    }
+  }
+
+  /// Opens the serial port for reading only.
+  Future<bool> openRead() => open(mode:0);
+
+  /// Opens the serial port for writing only.
+  Future<bool> openWrite() => open(mode:0);
+
+  /// Opens the serial port for reading and writing.
+  Future<bool> openReadWrite() => open(mode:0);
+
+  /// Closes the serial port.
+  Future<bool> close() async {
+    if(_reading != null) {
+      _reading!.cancel();
+      _reading = null;
+    }
+
+    if(isOpen && (port != null)) {
+      bool result = await port!.close();
+      _portOpened = !result;
+      return result;
+    }
+
+    return false;
+  }
+
+  /// Gets whether the serial port is open.
+  bool get isOpen => _portOpened;
+
+  /// Gets the name of the port.
+  ///
+  /// The name returned is whatever is normally used to refer to a port on the
+  /// current operating system; e.g. for Windows it will usually be a "COMn"
+  /// device name, and for Unix it will be a device path beginning with "/dev/".
+  String? get name => _device.deviceName;
+
+  /// Gets the description of the port, for presenting to end users.
+  String? get description => "";
+
+  /// Gets the transport type used by the port.
+  ///
+  /// See also:
+  /// - [SerialPortTransport]
+  int get transport => SerialPortTransport.usb;
+
+  /// Gets the USB bus number of a USB serial adapter port.
+  int? get busNumber => -1;
+
+  /// Gets the USB device number of a USB serial adapter port.
+  int? get deviceNumber => _device.deviceId;
+
+  /// Gets the USB vendor ID of a USB serial adapter port.
+  int? get vendorId => _device.vid;
+
+  /// Gets the USB Product ID of a USB serial adapter port.
+  int? get productId => _device.pid;
+
+  /// Gets the USB interface number.
+  int _interfaceNumber = -1;
+
+  int get interfaceNumber => _interfaceNumber;
+
+  set interfaceNumber(int val) {
+    _interfaceNumber = val;
+  }
+
+  int? get interfaceCount => _device.interfaceCount;
+
+  /// Get the USB manufacturer of a USB serial adapter port.
+  String? get manufacturer => _device.manufacturerName;
+
+  /// Gets the USB product name of a USB serial adapter port.
+  String? get productName => _device.productName;
+
+  /// Gets the USB serial number of a USB serial adapter port.
+  String? get serialNumber => _device.serial;
+
+  /// Gets the MAC address of a Bluetooth serial adapter port.
+  String? get macAddress => serialNumber;
+
+  SerialPortConfig? _config;
+
+  /// Gets the current configuration of the serial port.
+  SerialPortConfig get config => _config!;
+
+  /// Sets the configuration for the serial port.
+  ///
+  /// For each parameter in the configuration, there is a special value
+  /// (usually -1, but see the documentation for each field). These values
+  /// will be ignored and the corresponding setting left unchanged on the port.
+  ///
+  /// Upon errors, the configuration of the serial port is unknown since
+  /// partial/incomplete config updates may have happened.
+  Future<void> setConfig(SerialPortConfig config) async {
+    _config = config;
+
+    //Configure port
+    await port!.setDTR((config.dtr == SerialPortDtr.on));
+    await port!.setFlowControl(config.flowControl);
+    await port!.setPortParameters(config.baudRate, config.bits, config.stopBits, config.parity);
+    await port!.setRTS((config.rts == SerialPortRts.on));
+  }
+
+  /// Read data from the serial port.
+  ///
+  /// The operation attempts to read N `bytes` of data.
+  ///
+  /// If `timeout` is 0 or greater, the read operation is blocking.
+  /// The timeout is specified in milliseconds. Pass 0 to wait infinitely.
+  Future<Uint8List> read(int bytes, {int timeout = -1}) async {
+    if(_reading == null) {
+      _startReading();
+    }
+
+    if(dataAvailable.length >= bytes) {
+      Uint8List subData = dataAvailable.sublist(0, bytes);
+      dataAvailable = dataAvailable.sublist(bytes, dataAvailable.length);
+      return subData;
+    } else if(timeout != -1) {
+      int elapsedTime = 0;
+      do {
+        await Future.delayed(const Duration(milliseconds: 1));
+        elapsedTime++;
+
+        if(dataAvailable.length >= bytes) {
+          Uint8List subData = dataAvailable.sublist(0, bytes);
+          dataAvailable = dataAvailable.sublist(bytes, dataAvailable.length);
+          return subData;
+        }
+      } while(elapsedTime < timeout);
+    }
+
+    return Uint8List(0);
+  }
+
+  /// Write data to the serial port.
+  ///
+  /// If `timeout` is 0 or greater, the write operation is blocking.
+  /// The timeout is specified in milliseconds. Pass 0 to wait infinitely.
+  ///
+  /// Returns the amount of bytes written.
+  Future<int> write(Uint8List bytes, {int timeout = -1}) async {
+    if(port != null) {
+      await port!.write(bytes);
+      return bytes.length;
+    }
+
+    return -1;
+  }
+
+  /// Gets the amount of bytes available for reading.
+  int get bytesAvailable => dataAvailable.length;
+
+  /// Gets the amount of bytes waiting to be written.
+  int get bytesToWrite => 0;
+
+  /// Flushes serial port buffers. Data in the selected buffer(s) is discarded.
+  ///
+  /// See also:
+  /// - [SerialPortBuffer]
+  void flush([int buffers = SerialPortBuffer.both]) {
+    //Not available
+  }
+
+  /// Waits for buffered data to be transmitted.
+  void drain() {
+    //Not available
+  }
+
+  /// Gets the status of the control signals for the serial port.
+  int get signals => 0;
+
+  /// Puts the port transmit line into the break state.
+  bool startBreak() {
+    //Not available
+    return false;
+  }
+
+  /// Takes the port transmit line out of the break state.
+  bool endBreak() {
+    //Not available
+    return false;
+  }
+
+  /// Gets the error for a failed operation.
+  static SerialPortError? _err;
+  static SerialPortError? get lastError => _err;
+}
+
+/// Serial port config for Android.
+class SerialPortConfigAndroid implements SerialPortConfig {
+  SerialPortConfigAndroid(){}
+
+  /// @internal
+  factory SerialPortConfigAndroid.fromAddress(int address) {
+    SerialPortConfigAndroid conf = SerialPortConfigAndroid();
+    conf.address = address;
+    return conf;
+  }
+
+  /// @internal
+  int address = 0;
+
+  /// Releases all resources associated with the serial port config.
+  ///
+  /// @note Call this function after you're done with the serial port config.
+  void dispose(){}
+
+  /// Gets the baud rate from the port configuration.
+  int baudRate = 0;
+
+  /// Gets the data bits from the port configuration.
+  int bits = 0;
+
+  /// Gets the parity setting from the port configuration.
+  int _parity = 0;
+  int get parity => _parity;
+
+  /// Sets the parity setting in the port configuration.
+  set parity(int value) {
+    switch(value) {
+      case SerialPortParity.invalid:
+        _parity = -1;
+        break;
+      case SerialPortParity.none:
+        _parity = UsbPort.PARITY_NONE;
+        break;
+      case SerialPortParity.odd:
+        _parity = UsbPort.PARITY_ODD;
+        break;
+      case SerialPortParity.even:
+        _parity = UsbPort.PARITY_EVEN;
+        break;
+      case SerialPortParity.mark:
+        _parity = UsbPort.PARITY_MARK;
+        break;
+      case SerialPortParity.space:
+        _parity = UsbPort.PARITY_SPACE;
+        break;
+    }
+  }
+
+  /// Gets the stop bits from the port configuration.
+  int stopBits = 0;
+
+  /// Gets the RTS pin behaviour from the port configuration.
+  ///
+  /// See also:
+  /// - [SerialPortRts]
+  int rts = 0;
+
+  /// Gets the CTS pin behaviour from the port configuration.
+  ///
+  /// See also:
+  /// - [SerialPortCts]
+  int cts = 0;
+
+  /// Gets the DTR pin behaviour from the port configuration.
+  ///
+  /// See also:
+  /// - [SerialPortDtr]
+  int dtr = 0;
+
+  /// Gets the DSR pin behaviour from the port configuration.
+  ///
+  /// See also:
+  /// - [SerialPortDsr]
+  int dsr = 0;
+
+  /// Gets the XON/XOFF configuration from the port configuration.
+  ///
+  /// See also:
+  /// - [SerialPortXonXoff]
+  int xonXoff = 0;
+
+  /// Sets the flow control type in the port configuration.
+  ///
+  /// This function is a wrapper that sets the RTS, CTS, DTR, DSR and
+  /// XON/XOFF settings as necessary for the specified flow control
+  /// type. For more fine-grained control of these settings, use their
+  /// individual configuration functions.
+  ///
+  /// See also:
+  /// - [SerialPortFlowControl]
+  int _flowControl = 0;
+
+  void setFlowControl(int value) {
+    switch(value) {
+      case SerialPortFlowControl.none:
+        _flowControl = UsbPort.FLOW_CONTROL_OFF;
+        break;
+      case SerialPortFlowControl.xonXoff:
+        _flowControl = UsbPort.FLOW_CONTROL_XON_XOFF;
+        break;
+      case SerialPortFlowControl.rtsCts:
+        _flowControl = UsbPort.FLOW_CONTROL_RTS_CTS;
+        break;
+      case SerialPortFlowControl.dtrDsr:
+        _flowControl = UsbPort.FLOW_CONTROL_DSR_DTR;
+        break;
+      default:
+        _flowControl = UsbPort.FLOW_CONTROL_OFF;
+    }
+  }
+
+  int get flowControl => _flowControl;
+}

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -23,11 +23,13 @@
  */
 
 import 'dart:ffi' as ffi;
+import 'dart:io' show Platform;
 
 import 'package:ffi/ffi.dart' as ffi;
 import 'package:libserialport/src/bindings.dart';
 import 'package:libserialport/src/dylib.dart';
 import 'package:libserialport/src/util.dart';
+import 'package:libserialport/src/android.dart';
 
 /// Serial port config.
 ///
@@ -70,11 +72,22 @@ abstract class SerialPortConfig {
   ///
   /// @note Call [dispose()] to release the resources after you're done with
   ///       the serial port config.
-  factory SerialPortConfig() => _SerialPortConfigImpl();
+  factory SerialPortConfig() {
+    if (Platform.isAndroid) {
+      return SerialPortConfigAndroid();
+    } else {
+      return SerialPortConfigDesktop();
+    }
+  }
 
   /// @internal
-  factory SerialPortConfig.fromAddress(int address) =>
-      _SerialPortConfigImpl.fromAddress(address);
+  factory SerialPortConfig.fromAddress(int address) {
+    if (Platform.isAndroid) {
+      return SerialPortConfigAndroid.fromAddress(address);
+    } else {
+      return SerialPortConfigDesktop.fromAddress(address);
+    }
+  }
 
   /// @internal
   int get address;
@@ -178,6 +191,8 @@ abstract class SerialPortConfig {
   /// See also:
   /// - [SerialPortFlowControl]
   void setFlowControl(int value);
+
+  int get flowControl;
 }
 
 // ignore_for_file: avoid_private_typedef_functions
@@ -190,11 +205,11 @@ typedef _SerialPortConfigGet32 = int Function(
 typedef _SerialPortConfigSet = int Function(
     ffi.Pointer<sp_port_config> config, int value);
 
-class _SerialPortConfigImpl implements SerialPortConfig {
+class SerialPortConfigDesktop implements SerialPortConfig {
   final ffi.Pointer<sp_port_config> _config;
 
-  _SerialPortConfigImpl() : _config = _init();
-  _SerialPortConfigImpl.fromAddress(int address)
+  SerialPortConfigDesktop() : _config = _init();
+  SerialPortConfigDesktop.fromAddress(int address)
       : _config = ffi.Pointer<sp_port_config>.fromAddress(address);
 
   @override
@@ -279,7 +294,7 @@ class _SerialPortConfigImpl implements SerialPortConfig {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is _SerialPortConfigImpl && _config == other._config;
+    return other is SerialPortConfigDesktop && _config == other._config;
   }
 
   @override
@@ -287,4 +302,6 @@ class _SerialPortConfigImpl implements SerialPortConfig {
 
   @override
   String toString() => 'SerialPortConfig($_config)';
+
+  int get flowControl => 0;
 }

--- a/lib/src/port.dart
+++ b/lib/src/port.dart
@@ -24,8 +24,10 @@
 
 import 'dart:ffi' as ffi;
 import 'dart:typed_data';
+import 'dart:io' show Platform;
 
 import 'package:ffi/ffi.dart' as ffi;
+import 'package:libserialport/src/android.dart';
 import 'package:libserialport/src/bindings.dart';
 import 'package:libserialport/src/config.dart';
 import 'package:libserialport/src/dylib.dart';
@@ -69,17 +71,34 @@ abstract class SerialPort {
   ///
   /// **Note:** Call [dispose()] to release the resources after you're done
   ///           with the serial port.
-  factory SerialPort(String name) => _SerialPortImpl(name);
+  factory SerialPort(String name) {
+    if (Platform.isAndroid) {
+      return SerialPortAndroid(name);
+    } else {
+      return SerialPortDesktop(name);
+    }
+  }
 
   /// @internal
-  factory SerialPort.fromAddress(int address) =>
-      _SerialPortImpl.fromAddress(address);
+  factory SerialPort.fromAddress(int address) {
+    if (Platform.isAndroid) {
+      return SerialPortAndroid.fromAddress(address);
+    } else {
+      return SerialPortDesktop.fromAddress(address);
+    }
+  }
 
   /// @internal
   int get address;
 
   /// Lists the serial ports available on the system.
-  static List<String> get availablePorts => _SerialPortImpl.availablePorts;
+  static Future<List<String>> get availablePorts {
+    if (Platform.isAndroid) {
+      return SerialPortAndroid.availablePorts;
+    } else {
+      return SerialPortDesktop.availablePorts;
+    }
+  }
 
   /// Releases all resources associated with the serial port.
   ///
@@ -90,19 +109,19 @@ abstract class SerialPort {
   ///
   /// See also:
   /// - [SerialPortMode]
-  bool open({required int mode});
+  Future<bool> open({required int mode});
 
   /// Opens the serial port for reading only.
-  bool openRead();
+  Future<bool> openRead();
 
   /// Opens the serial port for writing only.
-  bool openWrite();
+  Future<bool> openWrite();
 
   /// Opens the serial port for reading and writing.
-  bool openReadWrite();
+  Future<bool> openReadWrite();
 
   /// Closes the serial port.
-  bool close();
+  Future<bool> close();
 
   /// Gets whether the serial port is open.
   bool get isOpen;
@@ -158,7 +177,7 @@ abstract class SerialPort {
   ///
   /// Upon errors, the configuration of the serial port is unknown since
   /// partial/incomplete config updates may have happened.
-  set config(SerialPortConfig config);
+  Future<void> setConfig(SerialPortConfig config);
 
   /// Read data from the serial port.
   ///
@@ -166,7 +185,7 @@ abstract class SerialPort {
   ///
   /// If `timeout` is 0 or greater, the read operation is blocking.
   /// The timeout is specified in milliseconds. Pass 0 to wait infinitely.
-  Uint8List read(int bytes, {int timeout = -1});
+  Future<Uint8List> read(int bytes, {int timeout = -1});
 
   /// Write data to the serial port.
   ///
@@ -174,7 +193,7 @@ abstract class SerialPort {
   /// The timeout is specified in milliseconds. Pass 0 to wait infinitely.
   ///
   /// Returns the amount of bytes written.
-  int write(Uint8List bytes, {int timeout = -1});
+  Future<int> write(Uint8List bytes, {int timeout = -1});
 
   /// Gets the amount of bytes available for reading.
   int get bytesAvailable;
@@ -201,15 +220,21 @@ abstract class SerialPort {
   bool endBreak();
 
   /// Gets the error for a failed operation.
-  static SerialPortError? get lastError => _SerialPortImpl.lastError;
+  static SerialPortError? get lastError {
+    if (Platform.isAndroid) {
+      return SerialPortAndroid.lastError;
+    } else {
+      return SerialPortDesktop.lastError;
+    }
+  }
 }
 
-class _SerialPortImpl implements SerialPort {
+class SerialPortDesktop implements SerialPort {
   final ffi.Pointer<sp_port> _port;
   SerialPortConfig? _config;
 
-  _SerialPortImpl(String name) : _port = _init(name);
-  _SerialPortImpl.fromAddress(int address)
+  SerialPortDesktop(String name) : _port = _init(name);
+  SerialPortDesktop.fromAddress(int address)
       : _port = ffi.Pointer<sp_port>.fromAddress(address);
 
   @override
@@ -225,7 +250,7 @@ class _SerialPortImpl implements SerialPort {
     return port;
   }
 
-  static List<String> get availablePorts {
+  static Future<List<String>> get availablePorts async {
     final out = ffi.calloc<ffi.Pointer<ffi.Pointer<sp_port>>>();
     final rv = Util.call(() => dylib.sp_list_ports(out));
     if (rv != sp_return.SP_OK) {
@@ -250,16 +275,16 @@ class _SerialPortImpl implements SerialPort {
   }
 
   @override
-  bool open({required int mode}) =>
+  Future<bool> open({required int mode}) async =>
       dylib.sp_open(_port, mode) == sp_return.SP_OK;
   @override
-  bool openRead() => open(mode: SerialPortMode.read);
+  Future<bool> openRead() async => open(mode: SerialPortMode.read);
   @override
-  bool openWrite() => open(mode: SerialPortMode.write);
+  Future<bool> openWrite() async => open(mode: SerialPortMode.write);
   @override
-  bool openReadWrite() => open(mode: SerialPortMode.readWrite);
+  Future<bool> openReadWrite() async => open(mode: SerialPortMode.readWrite);
   @override
-  bool close() => dylib.sp_close(_port) == sp_return.SP_OK;
+  Future<bool> close() async => dylib.sp_close(_port) == sp_return.SP_OK;
 
   @override
   bool get isOpen {
@@ -338,7 +363,7 @@ class _SerialPortImpl implements SerialPort {
   }
 
   @override
-  set config(SerialPortConfig config) {
+  Future<void> setConfig(SerialPortConfig config) async {
     if (_config != config) {
       _config?.dispose();
     }
@@ -348,7 +373,7 @@ class _SerialPortImpl implements SerialPort {
   }
 
   @override
-  Uint8List read(int bytes, {int timeout = -1}) {
+  Future<Uint8List> read(int bytes, {int timeout = -1}) async {
     return Util.read(bytes, (ffi.Pointer<ffi.Uint8> ptr) {
       return timeout < 0
           ? dylib.sp_nonblocking_read(_port, ptr.cast(), bytes)
@@ -357,7 +382,7 @@ class _SerialPortImpl implements SerialPort {
   }
 
   @override
-  int write(Uint8List bytes, {int timeout = -1}) {
+  Future<int> write(Uint8List bytes, {int timeout = -1}) async {
     return Util.write(bytes, (ffi.Pointer<ffi.Uint8> ptr) {
       return timeout < 0
           ? dylib.sp_nonblocking_write(_port, ptr.cast(), bytes.length)
@@ -403,7 +428,7 @@ class _SerialPortImpl implements SerialPort {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is _SerialPortImpl && _port == other._port;
+    return other is SerialPortDesktop && _port == other._port;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   dylib: ^0.3.2
   ffi: ^2.0.1
+  usb_serial: ^0.5.2
 
 dev_dependencies:
   ffigen: ^6.1.1


### PR DESCRIPTION
Android support is not working as the underlying lib is relying on system files ("/sys/class/tty") which requires rooted devices.
In order to provide a quick solution, I used [usb_serial](https://pub.dev/packages/usb_serial) as the underlying implementation of serial communication for Android.
It works smoothly and avoid redeveloping a solution from scratch, while keeping a single interface for Desktop and Android serial communication development.
There is a drawback, usb_serial only has an asynchronous interface, which requires updating libserialport functions to async, this breaks older software relying on synchronous interfaces.